### PR TITLE
Clarify port and protocol requirements

### DIFF
--- a/doc_source/agentconsole-guide.md
+++ b/doc_source/agentconsole-guide.md
@@ -55,7 +55,7 @@ Before agents can use the CCP, check the following configurations:
 
 Agents can log in using the URL, user name, and password provided by their Amazon Connect administrator\. Each agent has a unique user name and password\.
 
-If your agents use a softphone for Amazon Connect, you must allow traffic in both directions for the ports and addresses listed below, for the region in which you created your instance\.
+If your agents use a softphone for Amazon Connect, you must allow traffic outbound to the destination ports and addresses listed below, for the region in which you created your instance\.
 
 The IP addresses used by Amazon Connect for each region are listed, along with the addresses for all AWS services, in the [https://ip\-ranges\.amazonaws\.com/ip\-ranges\.json](https://ip-ranges.amazonaws.com/ip-ranges.json) file under the service name AMAZON\_CONNECT\. For agents to use the CCP, you also need to allow access for the softphone signaling endpoints, which are hosted in Amazon EC2\. For more information about IP address ranges in AWS, see [AWS IP Address Ranges](https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html)\.
 
@@ -66,7 +66,7 @@ When there are new IP address ranges supported for Amazon Connect, they are adde
 | --- | --- | --- | --- | 
 | HTTP | 80 | TCP | AWS EC2 and CLOUDFRONT ranges in [https://ip\-ranges\.amazonaws\.com/ip\-ranges\.json](https://ip-ranges.amazonaws.com/ip-ranges.json)\. | 
 | HTTPS | 443 | TCP | AWS EC2 and CLOUDFRONT ranges in [https://ip\-ranges\.amazonaws\.com/ip\-ranges\.json](https://ip-ranges.amazonaws.com/ip-ranges.json)\. | 
-| TURN/STUN | 3478 and 49152\-65535 | UDP | AMAZON\_CONNECT ranges in [https://ip\-ranges\.amazonaws\.com/ip\-ranges\.json](https://ip-ranges.amazonaws.com/ip-ranges.json)\. | 
+| TURN/STUN | 3478 | UDP | AMAZON\_CONNECT ranges in [https://ip\-ranges\.amazonaws\.com/ip\-ranges\.json](https://ip-ranges.amazonaws.com/ip-ranges.json)\. | 
 | TURN relay media | 80 and 443 | UDP and TCP | AMAZON\_CONNECT ranges in [https://ip\-ranges\.amazonaws\.com/ip\-ranges\.json](https://ip-ranges.amazonaws.com/ip-ranges.json)\. | 
 
 ### Status Settings<a name="status"></a>


### PR DESCRIPTION
The existing doc makes it sound like I need to allow traffic to the listed ports inbound on my firewall in addition to outbound. In reality I need only allow outbound to those destination ports, along with return traffic, right?

The chart also lists ephemeral ports for TURN/STUN, which I think adds to the confusion.

My change re-words the directionality requirement to simply say "outbound" (allowing corresponding return traffic is assumed, I think, in the age of stateful firewalls). It also removes the high-port range for TURN/STUN from the chart, which aligns that chart to a similar chart in "Amazon Connect Troubleshooting and Best Practices"->"Network Ports and Protocols" of the Administrator Guide. After this change, one discrepency remains between the charts in the two docs: the presence of port 80 in this chart.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
